### PR TITLE
Fix parser performance

### DIFF
--- a/library/PostgresqlSyntax/Parsing.hs
+++ b/library/PostgresqlSyntax/Parsing.hs
@@ -1070,13 +1070,29 @@ customizedAExpr cExpr = suffixRec base suffix where
     [ DefaultAExpr <$ keyword "default"
     , UniqueAExpr <$> (keyword "unique" *> space1 *> selectWithParens)
     , OverlapsAExpr
-    <$> wrapToHead row
+    <$> wrapToHead (ExplicitRowRow <$> explicitRow)
     <*> (space1 *> keyword "overlaps" *> space1 *> endHead *> row)
     , qualOpExpr aExpr PrefixQualOpAExpr
     , PlusAExpr <$> plusedExpr aExpr
     , MinusAExpr <$> minusedExpr aExpr
     , NotAExpr <$> (keyword "not" *> space1 *> aExpr)
-    , CExprAExpr <$> cExpr
+    , CExprAExpr <$> cExprNoCommonPrefix
+    , char '(' *> space *> asum
+      [ CExprAExpr <$> cExprTailNoCommonPrefix
+      , do
+        a <- wrapToHead aExpr
+        asum
+          [ do
+            b <- wrapToHead $ ImplicitRowRow <$> implicitRowTail a
+            space1
+            keyword "overlaps"
+            space1
+            endHead
+            c <- row
+            return $ OverlapsAExpr b c
+          , CExprAExpr . convertNestedParenSelect <$> cExprTailParenExpr a
+          ]
+      ]
     ]
   suffix a = asum
     [ typecastExpr a TypecastAExpr
@@ -1200,7 +1216,11 @@ customizedBExpr cExpr = suffixRec base suffix where
       return (IsOpBExpr a b c)
     ]
 
-cExpr = asum
+cExpr :: Parser CExpr
+cExpr = asum [cExprNoCommonPrefix, char '(' *> space *> cExprTailParen]
+
+cExprNoCommonPrefix :: Parser CExpr
+cExprNoCommonPrefix = asum
   [ cExprCommon
   , FuncCExpr <$> funcExprNoCommonPrefix
   , do
@@ -1209,29 +1229,12 @@ cExpr = asum
     asum [FuncCExpr <$> funcExprTail a, ColumnrefCExpr <$> columnrefCont a]
   ]
 
-customizedCExpr columnref =
-  asum [cExprCommon, FuncCExpr <$> funcExpr, ColumnrefCExpr <$> columnref]
-
+cExprCommon :: Parser CExpr
 cExprCommon = asum
   [ ParamCExpr <$> (char '$' *> decimal <* endHead) <*> optional
     (space *> indirection)
   , CaseCExpr <$> caseExpr
   , ExplicitRowCExpr <$> explicitRow
-  , char '(' *> space *> asum
-    [ do
-      a <- selectNoParens <* endHead <* space <* char ')'
-      b <- optional (space *> indirection)
-      return (SelectWithParensCExpr (NoParensSelectWithParens a) b)
-    , do
-      a <- aExpr
-      endHead
-      asum
-        [ ImplicitRowCExpr <$> implicitRowTail a
-        , convertNestedParenSelect
-        .   InParensCExpr a
-        <$> (space *> char ')' *> optional (space *> indirection))
-        ]
-    ]
   , inParensWithClause (keyword "grouping")
                        (GroupingCExpr <$> sep1 commaSeparator aExpr)
   , keyword "exists" *> space *> (ExistsCExpr <$> selectWithParens)
@@ -1244,6 +1247,43 @@ cExprCommon = asum
       ]
   , AexprConstCExpr <$> wrapToHead aexprConst
   ]
+
+-- cExpr following a '('
+cExprTailParen :: Parser CExpr
+cExprTailParen = asum
+  [ cExprTailNoCommonPrefix
+  , do
+    a <- aExpr
+    endHead
+    cExprTailParenExpr a
+  ]
+
+-- the part of the tail-parser of a cExpr after a '(' that does not have a
+-- @aExpr@ prefix.
+cExprTailNoCommonPrefix :: Parser CExpr
+cExprTailNoCommonPrefix = do
+  a <- selectNoParens <* endHead <* space <* char ')'
+  b <- optional (space *> indirection)
+  return (SelectWithParensCExpr (NoParensSelectWithParens a) b)
+
+-- cExpr following a '(' plus an @aExpr@.
+cExprTailParenExpr :: AExpr -> Parser CExpr
+cExprTailParenExpr a = asum
+  [ ImplicitRowCExpr <$> implicitRowTail a
+  , InParensCExpr a <$> (space *> char ')' *> optional (space *> indirection))
+  ]
+
+customizedCExpr :: Parser Columnref -> Parser CExpr
+customizedCExpr columnref = asum
+  [ cExprCommon
+  , char '(' *> space *> cExprTailParen
+  , FuncCExpr <$> funcExpr
+  , ColumnrefCExpr <$> columnref
+  ]
+
+
+openParenAExpr :: Parser AExpr
+openParenAExpr = char '(' *> space *> aExpr <* endHead
 
 convertNestedParenSelect :: CExpr -> CExpr
 convertNestedParenSelect cExpr = case go cExpr of
@@ -1310,6 +1350,12 @@ row = ExplicitRowRow <$> explicitRow <|> ImplicitRowRow <$> implicitRow
 explicitRow = keyword "row" *> space *> inParens (optional exprList)
 
 implicitRow = inParens (wrapToHead aExpr >>= implicitRowTailInner)
+-- implicitRow = inParens $ do
+--   a <- wrapToHead aExpr
+--   commaSeparator
+--   b <- exprList
+--   return $ case NonEmpty.consAndUnsnoc a b of
+--     (c, d) -> ImplicitRow c d
 
 -- the "tail" of the @implicitRow@ parser, i.e. the parser after the initial
 -- "( $EXPR" part.

--- a/library/PostgresqlSyntax/Parsing.hs
+++ b/library/PostgresqlSyntax/Parsing.hs
@@ -1073,26 +1073,22 @@ customizedAExpr cExpr = suffixRec base suffix where
     , CExprAExpr <$> cExpr
     ]
   suffix a = asum
-    [ asum
+    [ typecastExpr a TypecastAExpr
+    , symbolicBinOpExpr a aExpr SymbolicBinOpAExpr
+    , space1 *> asum
       [ do
-        space1
         b <- wrapToHead subqueryOp
         space1
         c <- wrapToHead subType
         space
         d <- Left <$> wrapToHead selectWithParens <|> Right <$> inParens aExpr
         return (SubqueryAExpr a b c d)
-      , typecastExpr a TypecastAExpr
-      , CollateAExpr a
-        <$> (space1 *> keyword "collate" *> space1 *> endHead *> anyName)
+      , CollateAExpr a <$> (keyword "collate" *> space1 *> endHead *> anyName)
       , AtTimeZoneAExpr a
-        <$> (space1 *> keyphrase "at time zone" *> space1 *> endHead *> aExpr)
-      , symbolicBinOpExpr a aExpr SymbolicBinOpAExpr
-      , SuffixQualOpAExpr a <$> (space *> qualOp)
-      , AndAExpr a <$> (space1 *> keyword "and" *> space1 *> endHead *> aExpr)
-      , OrAExpr a <$> (space1 *> keyword "or" *> space1 *> endHead *> aExpr)
+        <$> (keyphrase "at time zone" *> space1 *> endHead *> aExpr)
+      , AndAExpr a <$> (keyword "and" *> space1 *> endHead *> aExpr)
+      , OrAExpr a <$> (keyword "or" *> space1 *> endHead *> aExpr)
       , do
-        space1
         b <- trueIfPresent (keyword "not" *> space1)
         c <- asum
           [ LikeVerbalExprBinOp <$ keyword "like"
@@ -1105,7 +1101,6 @@ customizedAExpr cExpr = suffixRec base suffix where
         e <- optional (space1 *> keyword "escape" *> space1 *> endHead *> aExpr)
         return (VerbalExprBinOpAExpr a b c d e)
       , do
-        space1
         keyword "is"
         space1
         endHead
@@ -1129,7 +1124,6 @@ customizedAExpr cExpr = suffixRec base suffix where
           ]
         return (ReversableOpAExpr a b c)
       , do
-        space1
         b <- trueIfPresent (keyword "not" *> space1)
         keyword "between"
         space1
@@ -1146,15 +1140,18 @@ customizedAExpr cExpr = suffixRec base suffix where
         e <- aExpr
         return (ReversableOpAExpr a b (c d e))
       , do
-        space1
         b <- trueIfPresent (keyword "not" *> space1)
         keyword "in"
         space
         c <- InAExprReversableOp <$> inExpr
         return (ReversableOpAExpr a b c)
-      , IsnullAExpr a <$ (space1 *> keyword "isnull")
-      , NotnullAExpr a <$ (space1 *> keyword "notnull")
+      , IsnullAExpr a <$ (keyword "isnull")
+      , NotnullAExpr a <$ (keyword "notnull")
       ]
+    , SuffixQualOpAExpr a <$> (space *> qualOp)
+      -- TODO SuffixQualOpAExpr has a common prefix with SubqueryAExpr
+      -- so for now we rely on the order of the parsers here, which works well
+      -- enough.
     ]
 
 bExpr = customizedBExpr cExpr

--- a/library/PostgresqlSyntax/Parsing.hs
+++ b/library/PostgresqlSyntax/Parsing.hs
@@ -60,6 +60,7 @@ import qualified Text.Megaparsec.Char.Lexer    as MegaparsecLexer
 import qualified PostgresqlSyntax.KeywordSet   as KeywordSet
 import qualified PostgresqlSyntax.Predicate    as Predicate
 import qualified PostgresqlSyntax.Validation   as Validation
+import qualified Data.Char                     as Char
 import qualified Data.Text                     as Text
 import qualified Data.List.NonEmpty            as NonEmpty
 import qualified Text.Builder                  as TextBuilder
@@ -2122,7 +2123,14 @@ anyKeyword = parse $ Megaparsec.label "keyword" $ do
   return (Text.toLower (Text.cons _firstChar _remainder))
 
 {-| Expected keyword -}
-keyword a = mfilter (a ==) anyKeyword
+-- keyword a = mfilter (a ==) anyKeyword
+keyword a = parse $ Megaparsec.label "keyword" $ do
+  _firstChar <- Megaparsec.satisfy Predicate.firstIdentifierChar
+  guard (Char.toLower _firstChar == Text.head a)
+  _remainder <- Megaparsec.takeWhileP Nothing Predicate.notFirstIdentifierChar
+  let r = Text.toLower (Text.cons _firstChar _remainder)
+  guard (r == a)
+  return r
 
 {-|
 Consume a keyphrase, ignoring case and types of spaces between words.

--- a/library/PostgresqlSyntax/Parsing.hs
+++ b/library/PostgresqlSyntax/Parsing.hs
@@ -1080,6 +1080,11 @@ customizedAExpr cExpr = suffixRec base suffix where
     ]
   suffix a = asum
     [ typecastExpr a TypecastAExpr
+      -- we could just use `base` instead of `aExpr` for the BinOp, would
+      -- lead to slightly different trees. I am not completely convinced that
+      -- `wrapHead` catches the case where you have a sequence of expressions
+      -- and operators followed by something that does not parse (my fear is
+      -- that it would repeatedly fail for each level).
     , symbolicBinOpExpr a aExpr SymbolicBinOpAExpr
     , space1 *> asum
       [ do
@@ -1173,6 +1178,11 @@ customizedBExpr cExpr = suffixRec base suffix where
     ]
   suffix a = asum
     [ typecastExpr a TypecastBExpr
+      -- we could just use `base` instead of `bExpr` for the BinOp, would
+      -- lead to slightly different trees. I am not completely convinced that
+      -- `wrapHead` catches the case where you have a sequence of expressions
+      -- and operators followed by something that does not parse (my fear is
+      -- that it would repeatedly fail for each level).
     , symbolicBinOpExpr a bExpr SymbolicBinOpBExpr
     , do
       space1

--- a/library/PostgresqlSyntax/Parsing.hs
+++ b/library/PostgresqlSyntax/Parsing.hs
@@ -1073,86 +1073,88 @@ customizedAExpr cExpr = suffixRec base suffix where
     , CExprAExpr <$> cExpr
     ]
   suffix a = asum
-    [ do
-      space1
-      b <- wrapToHead subqueryOp
-      space1
-      c <- wrapToHead subType
-      space
-      d <- Left <$> wrapToHead selectWithParens <|> Right <$> inParens aExpr
-      return (SubqueryAExpr a b c d)
-    , typecastExpr a TypecastAExpr
-    , CollateAExpr a
-      <$> (space1 *> keyword "collate" *> space1 *> endHead *> anyName)
-    , AtTimeZoneAExpr a
-      <$> (space1 *> keyphrase "at time zone" *> space1 *> endHead *> aExpr)
-    , symbolicBinOpExpr a aExpr SymbolicBinOpAExpr
-    , SuffixQualOpAExpr a <$> (space *> qualOp)
-    , AndAExpr a <$> (space1 *> keyword "and" *> space1 *> endHead *> aExpr)
-    , OrAExpr a <$> (space1 *> keyword "or" *> space1 *> endHead *> aExpr)
-    , do
-      space1
-      b <- trueIfPresent (keyword "not" *> space1)
-      c <- asum
-        [ LikeVerbalExprBinOp <$ keyword "like"
-        , IlikeVerbalExprBinOp <$ keyword "ilike"
-        , SimilarToVerbalExprBinOp <$ keyphrase "similar to"
-        ]
-      space1
-      endHead
-      d <- aExpr
-      e <- optional (space1 *> keyword "escape" *> space1 *> endHead *> aExpr)
-      return (VerbalExprBinOpAExpr a b c d e)
-    , do
-      space1
-      keyword "is"
-      space1
-      endHead
-      b <- trueIfPresent (keyword "not" *> space1)
-      c <- asum
-        [ NullAExprReversableOp <$ keyword "null"
-        , TrueAExprReversableOp <$ keyword "true"
-        , FalseAExprReversableOp <$ keyword "false"
-        , UnknownAExprReversableOp <$ keyword "unknown"
-        , DistinctFromAExprReversableOp
-          <$> (  keyword "distinct"
-              *> space1
-              *> keyword "from"
-              *> space1
-              *> endHead
-              *> aExpr
-              )
-        , OfAExprReversableOp
-          <$> (keyword "of" *> space1 *> endHead *> inParens typeList)
-        , DocumentAExprReversableOp <$ keyword "document"
-        ]
-      return (ReversableOpAExpr a b c)
-    , do
-      space1
-      b <- trueIfPresent (keyword "not" *> space1)
-      keyword "between"
-      space1
-      endHead
-      c <- asum
-        [ BetweenSymmetricAExprReversableOp <$ (keyword "symmetric" *> space1)
-        , BetweenAExprReversableOp True <$ (keyword "asymmetric" *> space1)
-        , pure (BetweenAExprReversableOp False)
-        ]
-      d <- bExpr
-      space1
-      keyword "and"
-      space1
-      e <- aExpr
-      return (ReversableOpAExpr a b (c d e))
-    , do
-      space1
-      b <- trueIfPresent (keyword "not" *> space1)
-      keyword "in"
-      space
-      c <- InAExprReversableOp <$> inExpr
-      return (ReversableOpAExpr a b c)
-    , IsnullAExpr a <$ (space1 *> keyword "isnull")
-    , NotnullAExpr a <$ (space1 *> keyword "notnull")
+    [ asum
+      [ do
+        space1
+        b <- wrapToHead subqueryOp
+        space1
+        c <- wrapToHead subType
+        space
+        d <- Left <$> wrapToHead selectWithParens <|> Right <$> inParens aExpr
+        return (SubqueryAExpr a b c d)
+      , typecastExpr a TypecastAExpr
+      , CollateAExpr a
+        <$> (space1 *> keyword "collate" *> space1 *> endHead *> anyName)
+      , AtTimeZoneAExpr a
+        <$> (space1 *> keyphrase "at time zone" *> space1 *> endHead *> aExpr)
+      , symbolicBinOpExpr a aExpr SymbolicBinOpAExpr
+      , SuffixQualOpAExpr a <$> (space *> qualOp)
+      , AndAExpr a <$> (space1 *> keyword "and" *> space1 *> endHead *> aExpr)
+      , OrAExpr a <$> (space1 *> keyword "or" *> space1 *> endHead *> aExpr)
+      , do
+        space1
+        b <- trueIfPresent (keyword "not" *> space1)
+        c <- asum
+          [ LikeVerbalExprBinOp <$ keyword "like"
+          , IlikeVerbalExprBinOp <$ keyword "ilike"
+          , SimilarToVerbalExprBinOp <$ keyphrase "similar to"
+          ]
+        space1
+        endHead
+        d <- aExpr
+        e <- optional (space1 *> keyword "escape" *> space1 *> endHead *> aExpr)
+        return (VerbalExprBinOpAExpr a b c d e)
+      , do
+        space1
+        keyword "is"
+        space1
+        endHead
+        b <- trueIfPresent (keyword "not" *> space1)
+        c <- asum
+          [ NullAExprReversableOp <$ keyword "null"
+          , TrueAExprReversableOp <$ keyword "true"
+          , FalseAExprReversableOp <$ keyword "false"
+          , UnknownAExprReversableOp <$ keyword "unknown"
+          , DistinctFromAExprReversableOp
+            <$> (  keyword "distinct"
+                *> space1
+                *> keyword "from"
+                *> space1
+                *> endHead
+                *> aExpr
+                )
+          , OfAExprReversableOp
+            <$> (keyword "of" *> space1 *> endHead *> inParens typeList)
+          , DocumentAExprReversableOp <$ keyword "document"
+          ]
+        return (ReversableOpAExpr a b c)
+      , do
+        space1
+        b <- trueIfPresent (keyword "not" *> space1)
+        keyword "between"
+        space1
+        endHead
+        c <- asum
+          [ BetweenSymmetricAExprReversableOp <$ (keyword "symmetric" *> space1)
+          , BetweenAExprReversableOp True <$ (keyword "asymmetric" *> space1)
+          , pure (BetweenAExprReversableOp False)
+          ]
+        d <- bExpr
+        space1
+        keyword "and"
+        space1
+        e <- aExpr
+        return (ReversableOpAExpr a b (c d e))
+      , do
+        space1
+        b <- trueIfPresent (keyword "not" *> space1)
+        keyword "in"
+        space
+        c <- InAExprReversableOp <$> inExpr
+        return (ReversableOpAExpr a b c)
+      , IsnullAExpr a <$ (space1 *> keyword "isnull")
+      , NotnullAExpr a <$ (space1 *> keyword "notnull")
+      ]
     ]
 
 bExpr = customizedBExpr cExpr


### PR DESCRIPTION
Hey, thanks for maintaining this package! And for considering this non-trivial PR :)

This PR fixes some bad parsing behaviour that leads to exponential time usage.

This PR looks big, but note that I applied an auto-formatter on `Parsing.hs` before I started to work on it. If this is a blocker just tell me and I can rebase the changes on a non-auto-formatted branch. To see the changes beyond auto-formatting see https://github.com/proda-ai/postgresql-syntax/pull/2, which is everything but the first commit here.

## Testcase

~~~~
((((((    ( COALESCE (mytable.oiuqweu_puiwrip_eoprdc, 0)
          + COALESCE (mytable.insdad_eoprdc, 0)
          + COALESCE (mytable.basdnasd_rates_eoprdc, 0)
          + COALESCE (mytable.poadpod_tpio_eoprdc, 0)
          + COALESCE (mytable.mkadldod_puiwrip_eoprdc, 0)
          + COALESCE (mytable.woidp_eoprdc, 0)
          + COALESCE (mytable.poiqwehda_eoprdc, 0)
          + COALESCE (mytable.htaing_eoprdc, 0)
          + COALESCE (mytable.clingd_eoprdc, 0)
          + COALESCE (mytable.lkjaldjj_eoprdc, 0)
          + COALESCE (mytable.dopasdop_eoprdc, 0)
          + COALESCE (mytable.thotd_idiaspdoid_eoprdc, 0)
          ) - 
          ( COALESCE (mytable.poadpod_tpio, 0)
          + COALESCE (mytable.mkadldod_puiwrip, 0)
          + COALESCE (mytable.insdad_poaisd, 0)
          + COALESCE (mytable.basdnasd_rates_poaisd, 0)
          + COALESCE (mytable.oiuqweu_puiwrip_poaisd, 0)
          + COALESCE (mytable.lkjfjf_dopasdop_cost_iuasudd, 0)
          + COALESCE (mytable.lkjfjf_htaing_iuasudd, 0)
          + COALESCE (mytable.prepaud_dopasdop_cost_poaisd, 0)
          + COALESCE (mytable.prepaud_mkadldod_puiwrip_poaisd, 0)
          + COALESCE (mytable.prepaud_woidp_poaisd, 0)
          + COALESCE (mytable.prepaud_poiqwehda_poaisd, 0)
          + COALESCE (mytable.thotd_idiaspdoid_poaisd, 0)
          + COALESCE (mytable.lkjfjf_woidp_iuasudd, 0)
          + COALESCE (mytable.lkjfjf_poiqwehda_iuasudd, 0)
          + COALESCE (mytable.lkjfjf_clingd_iuasudd, 0)
          + COALESCE (mytable.lkjfjf_lkjaldjj_iuasudd, 0)
          + COALESCE (mytable.prepaud_clingd_poaisd, 0)
          + COALESCE (mytable.prepaud_lkjaldjj_poaisd, 0)
          + COALESCE (mytable.prepaud_htaing_poaisd, 0)
          + COALESCE (mytable.prepaud_thotd_idiaspdoid_poaisd, 0)
          + COALESCE (mytable.lkjfjf_thotd_idiaspdoid_iuasudd, 0)
          + COALESCE (mytable.lkjfjf_mkadldod_puiwrip_iuasudd, 0)
          + COALESCE (mytable.dopasdop_eoprdc_poaisd, 0)
          + COALESCE (mytable.htaing_poaisd, 0)
          + COALESCE (mytable.clingd_poaisd, 0)
          + COALESCE (mytable.woidp_poaisd, 0)
          + COALESCE (mytable.poiqwehda_poaisd, 0)
          + COALESCE (mytable.lkjaldjj_poaisd, 0)
          )
))))))
~~~~

Parsing this does terminate, but you definitely start noticing the cpu time, and if you profile you can see some suspiciously large values. We had some larger queries that did _not_ terminate, but with the same underlying problem.

## Analysis

There are a couple of parsers around `aExpr`, `customizedAExpr`, `cExpr`, `customizedCExpr` that have alternatives with common prefixes and with ambiguous parses. 

1) Examples of common prefixes are:

- spaces in alternatives (`customizedAExpr`/`suffix`)
- open parenthesis + `aExpr` is a prefix of both `InParensCExpr` or `ImplicitRowCExpr`
- `colId` is a prefix of both `FuncCExpr` and `ColumnrefCExpr`

On their own these might be harmless, but once such cases nest they can create a problem. I _think_ the last of the above is just a constant-factor problem (so rather harmless); still, I cleaned these up in the PR because a) it was relatively simple to do b) It is hard to diagnose which common prefixes lead to problems, so it makes debugging the whole thing easier if they get cleaned up.

2) As example of a ambiguous parse consider the following two trees:

~~~~
InParensCExpr (SelectWithParensCExpr (NoParensSelectWithParens a) Nothing)
SelectWithParensCExpr (WithParensSelectWithParens a) Nothing
~~~~

both should correspond to something like `((SELECT …))`.

The ambiguity _might_ be known because the hedgehog tests explicitly generate only one of those two options (see https://github.com/nikita-volkov/postgresql-syntax/blob/6caff75d1a22af91806b689513888561731fb839/hedgehog-test/Main/Gen.hs#L475).

## Approach

I follow a simple process: Take any alternative (`asum [..]`) where alternatives have common prefixes, remove those alternatives and replace with a single new one that first matches the common prefix, then branches again. As an example, I replaced

~~~~
… = asum
  [ …
  , inParens foo
  , inParens bar
  , …
  ]
~~~~

with

~~~~
… = asum
  [ …
  , char '(' *> space *> asum [ fooTail, barTail ] *< space *< char ')'
  , …
  ]
~~~~

It is not always this simple, for example if the `inParens` appears deeper in the call stack then this gets messier, with multiple new `XTail` bindings.

## Notes

- I am not sure if I applied `endHead` and `wrapHead` correctly everywhere. The tests pass, but I am not sure that the tests cover the readability of the error-messages (iiuc the "HeadParser" also has the purpose of helping with those).
- There are some cases still where the order of the parsers (in `asum`s) matters. I don't think that is ideal, nor should it be necessary. As I understand it this might be due to committing to some branch (via `endHead`) too soon. But it is also harmless given that the tests pass.
- I added https://github.com/proda-ai/postgresql-syntax/blob/e0450870e35dcbfd4a11d6757bcb54c4bd65cc10/library/PostgresqlSyntax/Parsing.hs#L1288-L1301 after resolving the ambiguity-problem: The tests expect nested `WithParensSelectWithParens`, so the parser simply converts `InParensCExpr (CExprAExpr …)` to that where necessary. Could instead fix the tests, but maybe the slightly flatter trees for nested selects are worth this cost. I have no idea why exactly the AST types are defined as they are, to be honest.
- I feel like the code now combines several different approaches to ensure good performance:
  - the `customizedCExpr` approach to parameterise by some child-parser
  - just defining multiple parsers
  - defining "tail" parsers (what I did here)

  I am not proud of my addition as it makes the whole logic harder to follow. It might be cleaner make use of continuations, but still that does not improve things much. But I don't see an easy-to-read/maintain approach with good performance ..

  At least I only had to touch the "innermost loop" when parsing expressions, so maybe it is worth it.

- the fact that this https://github.com/nikita-volkov/postgresql-syntax/blob/6caff75d1a22af91806b689513888561731fb839/library/PostgresqlSyntax/Parsing.hs#L1025 uses `aExpr` instead of `base` means that a) you get a more "left-leaning" output tree but also b) that if parsing fails, you might end up failing again and again for every level of a nested `aExpr`. Same for `bExpr`. I left a note about this in the code. Could be fixed by the same "parse different tree (using `base`), then post-process to restructure the tree" approach that I used for nested selects.
- might be nice to have performance tests included. There should be some simple trivial expression like `((((((((((a+b))))))))))` that where parsing does not terminate on master but is instant with this PR. Might need a bit more nesting. But yeah, perf tests are a bit annoying at times because they can depend on the performance of the system running the tests.