### PR TITLE
Fix parser performance rebased

### DIFF
--- a/library/PostgresqlSyntax/Parsing.hs
+++ b/library/PostgresqlSyntax/Parsing.hs
@@ -1902,7 +1902,7 @@ firstOrNext =
     <|> True <$ keyword "next"
 
 selectFetchFirstValue =
-  ExprSelectFetchFirstValue <$> cExpr
+  ExprSelectFetchFirstValue . convertNestedParenSelect <$> cExpr
     <|> NumSelectFetchFirstValue <$> (plusOrMinus <* endHead <* space) <*> iconstOrFconst
 
 plusOrMinus = False <$ char '+' <|> True <$ char '-'

--- a/library/PostgresqlSyntax/Parsing.hs
+++ b/library/PostgresqlSyntax/Parsing.hs
@@ -985,6 +985,11 @@ customizedAExpr cExpr = suffixRec base suffix
     suffix a =
       asum
         [ typecastExpr a TypecastAExpr,
+          -- we could just use `base` instead of `aExpr` for the BinOp, would
+          -- lead to slightly different trees. I am not completely convinced that
+          -- `wrapHead` catches the case where you have a sequence of expressions
+          -- and operators followed by something that does not parse (my fear is
+          -- that it would repeatedly fail for each level).
           symbolicBinOpExpr a aExpr SymbolicBinOpAExpr,
           space1
             *> asum
@@ -1085,6 +1090,11 @@ customizedBExpr cExpr = suffixRec base suffix
     suffix a =
       asum
         [ typecastExpr a TypecastBExpr,
+          -- we could just use `base` instead of `bExpr` for the BinOp, would
+          -- lead to slightly different trees. I am not completely convinced that
+          -- `wrapHead` catches the case where you have a sequence of expressions
+          -- and operators followed by something that does not parse (my fear is
+          -- that it would repeatedly fail for each level).
           symbolicBinOpExpr a bExpr SymbolicBinOpBExpr,
           do
             space1

--- a/library/PostgresqlSyntax/Parsing.hs
+++ b/library/PostgresqlSyntax/Parsing.hs
@@ -976,81 +976,94 @@ customizedAExpr cExpr = suffixRec base suffix
           CExprAExpr <$> cExpr
         ]
     suffix a =
-      asum
-        [ do
-            space1
-            b <- wrapToHead subqueryOp
-            space1
-            c <- wrapToHead subType
-            space
-            d <- Left <$> wrapToHead selectWithParens <|> Right <$> inParens aExpr
-            return (SubqueryAExpr a b c d),
-          typecastExpr a TypecastAExpr,
-          CollateAExpr a <$> (space1 *> keyword "collate" *> space1 *> endHead *> anyName),
-          AtTimeZoneAExpr a <$> (space1 *> keyphrase "at time zone" *> space1 *> endHead *> aExpr),
-          symbolicBinOpExpr a aExpr SymbolicBinOpAExpr,
-          SuffixQualOpAExpr a <$> (space *> qualOp),
-          AndAExpr a <$> (space1 *> keyword "and" *> space1 *> endHead *> aExpr),
-          OrAExpr a <$> (space1 *> keyword "or" *> space1 *> endHead *> aExpr),
+      do
+        do
           do
-            space1
-            b <- trueIfPresent (keyword "not" *> space1)
-            c <-
-              asum
-                [ LikeVerbalExprBinOp <$ keyword "like",
-                  IlikeVerbalExprBinOp <$ keyword "ilike",
-                  SimilarToVerbalExprBinOp <$ keyphrase "similar to"
-                ]
-            space1
-            endHead
-            d <- aExpr
-            e <- optional (space1 *> keyword "escape" *> space1 *> endHead *> aExpr)
-            return (VerbalExprBinOpAExpr a b c d e),
-          do
-            space1
-            keyword "is"
-            space1
-            endHead
-            b <- trueIfPresent (keyword "not" *> space1)
-            c <-
-              asum
-                [ NullAExprReversableOp <$ keyword "null",
-                  TrueAExprReversableOp <$ keyword "true",
-                  FalseAExprReversableOp <$ keyword "false",
-                  UnknownAExprReversableOp <$ keyword "unknown",
-                  DistinctFromAExprReversableOp <$> (keyword "distinct" *> space1 *> keyword "from" *> space1 *> endHead *> aExpr),
-                  OfAExprReversableOp <$> (keyword "of" *> space1 *> endHead *> inParens typeList),
-                  DocumentAExprReversableOp <$ keyword "document"
-                ]
-            return (ReversableOpAExpr a b c),
-          do
-            space1
-            b <- trueIfPresent (keyword "not" *> space1)
-            keyword "between"
-            space1
-            endHead
-            c <-
-              asum
-                [ BetweenSymmetricAExprReversableOp <$ (keyword "symmetric" *> space1),
-                  BetweenAExprReversableOp True <$ (keyword "asymmetric" *> space1),
-                  pure (BetweenAExprReversableOp False)
-                ]
-            d <- bExpr
-            space1
-            keyword "and"
-            space1
-            e <- aExpr
-            return (ReversableOpAExpr a b (c d e)),
-          do
-            space1
-            b <- trueIfPresent (keyword "not" *> space1)
-            keyword "in"
-            space
-            c <- InAExprReversableOp <$> inExpr
-            return (ReversableOpAExpr a b c),
-          IsnullAExpr a <$ (space1 *> keyword "isnull"),
-          NotnullAExpr a <$ (space1 *> keyword "notnull")
-        ]
+            asum
+              [ do
+                  space1
+                  b <- wrapToHead subqueryOp
+                  space1
+                  c <- wrapToHead subType
+                  space
+                  d <- Left <$> wrapToHead selectWithParens <|> Right <$> inParens aExpr
+                  return (SubqueryAExpr a b c d),
+                typecastExpr a TypecastAExpr,
+                CollateAExpr a
+                  <$> (space1 *> keyword "collate" *> space1 *> endHead *> anyName),
+                AtTimeZoneAExpr a
+                  <$> (space1 *> keyphrase "at time zone" *> space1 *> endHead *> aExpr),
+                symbolicBinOpExpr a aExpr SymbolicBinOpAExpr,
+                SuffixQualOpAExpr a <$> (space *> qualOp),
+                AndAExpr a <$> (space1 *> keyword "and" *> space1 *> endHead *> aExpr),
+                OrAExpr a <$> (space1 *> keyword "or" *> space1 *> endHead *> aExpr),
+                do
+                  space1
+                  b <- trueIfPresent (keyword "not" *> space1)
+                  c <-
+                    asum
+                      [ LikeVerbalExprBinOp <$ keyword "like",
+                        IlikeVerbalExprBinOp <$ keyword "ilike",
+                        SimilarToVerbalExprBinOp <$ keyphrase "similar to"
+                      ]
+                  space1
+                  endHead
+                  d <- aExpr
+                  e <- optional (space1 *> keyword "escape" *> space1 *> endHead *> aExpr)
+                  return (VerbalExprBinOpAExpr a b c d e),
+                do
+                  space1
+                  keyword "is"
+                  space1
+                  endHead
+                  b <- trueIfPresent (keyword "not" *> space1)
+                  c <-
+                    asum
+                      [ NullAExprReversableOp <$ keyword "null",
+                        TrueAExprReversableOp <$ keyword "true",
+                        FalseAExprReversableOp <$ keyword "false",
+                        UnknownAExprReversableOp <$ keyword "unknown",
+                        DistinctFromAExprReversableOp
+                          <$> ( keyword "distinct"
+                                  *> space1
+                                  *> keyword "from"
+                                  *> space1
+                                  *> endHead
+                                  *> aExpr
+                              ),
+                        OfAExprReversableOp
+                          <$> (keyword "of" *> space1 *> endHead *> inParens typeList),
+                        DocumentAExprReversableOp <$ keyword "document"
+                      ]
+                  return (ReversableOpAExpr a b c),
+                do
+                  space1
+                  b <- trueIfPresent (keyword "not" *> space1)
+                  keyword "between"
+                  space1
+                  endHead
+                  c <-
+                    asum
+                      [ BetweenSymmetricAExprReversableOp <$ (keyword "symmetric" *> space1),
+                        BetweenAExprReversableOp True <$ (keyword "asymmetric" *> space1),
+                        pure (BetweenAExprReversableOp False)
+                      ]
+                  d <- bExpr
+                  space1
+                  keyword "and"
+                  space1
+                  e <- aExpr
+                  return (ReversableOpAExpr a b (c d e)),
+                do
+                  space1
+                  b <- trueIfPresent (keyword "not" *> space1)
+                  keyword "in"
+                  space
+                  c <- InAExprReversableOp <$> inExpr
+                  return (ReversableOpAExpr a b c),
+                IsnullAExpr a <$ (space1 *> keyword "isnull"),
+                NotnullAExpr a <$ (space1 *> keyword "notnull")
+              ]
 
 bExpr = customizedBExpr cExpr
 
@@ -1077,8 +1090,10 @@ customizedBExpr cExpr = suffixRec base suffix
             b <- trueIfPresent (keyword "not" *> space1)
             c <-
               asum
-                [ DistinctFromBExprIsOp <$> (keyphrase "distinct from" *> space1 *> endHead *> bExpr),
-                  OfBExprIsOp <$> (keyword "of" *> space1 *> endHead *> inParens typeList),
+                [ DistinctFromBExprIsOp
+                    <$> (keyphrase "distinct from" *> space1 *> endHead *> bExpr),
+                  OfBExprIsOp
+                    <$> (keyword "of" *> space1 *> endHead *> inParens typeList),
                   DocumentBExprIsOp <$ keyword "document"
                 ]
             return (IsOpBExpr a b c)

--- a/library/PostgresqlSyntax/Parsing.hs
+++ b/library/PostgresqlSyntax/Parsing.hs
@@ -1169,8 +1169,14 @@ row = ExplicitRowRow <$> explicitRow <|> ImplicitRowRow <$> implicitRow
 
 explicitRow = keyword "row" *> space *> inParens (optional exprList)
 
-implicitRow = inParens $ do
-  a <- wrapToHead aExpr
+implicitRow = inParens (wrapToHead aExpr >>= implicitRowTailInner)
+
+-- the "tail" of the @implicitRow@ parser, i.e. the parser after the initial
+-- "( $EXPR" part.
+implicitRowTail :: AExpr -> Parser ImplicitRow
+implicitRowTail a = implicitRowTailInner a <* space <* char ')'
+
+implicitRowTailInner a = do
   commaSeparator
   b <- exprList
   return $ case NonEmpty.consAndUnsnoc a b of

--- a/library/PostgresqlSyntax/Parsing.hs
+++ b/library/PostgresqlSyntax/Parsing.hs
@@ -27,6 +27,7 @@ module PostgresqlSyntax.Parsing where
 
 import Control.Applicative.Combinators hiding (some)
 import Control.Applicative.Combinators.NonEmpty
+import qualified Data.Char as Char
 import qualified Data.HashSet as HashSet
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Text as Text
@@ -1999,7 +2000,15 @@ anyKeyword = parse $
     return (Text.toLower (Text.cons _firstChar _remainder))
 
 -- | Expected keyword
-keyword a = mfilter (a ==) anyKeyword
+-- keyword a = mfilter (a ==) anyKeyword
+keyword a = parse $
+  Megaparsec.label "keyword" $ do
+    _firstChar <- Megaparsec.satisfy Predicate.firstIdentifierChar
+    guard (Char.toLower _firstChar == Text.head a)
+    _remainder <- Megaparsec.takeWhileP Nothing Predicate.notFirstIdentifierChar
+    let r = Text.toLower (Text.cons _firstChar _remainder)
+    guard (r == a)
+    return r
 
 -- |
 -- Consume a keyphrase, ignoring case and types of spaces between words.


### PR DESCRIPTION
Rebased version of the previous PR at https://github.com/nikita-volkov/postgresql-syntax/pull/2. Now based on the upstream formatting.

----

Hey, thanks for maintaining this package! And for considering this non-trivial PR :)

This PR fixes some bad parsing behaviour that leads to exponential time usage.

## Testcase

~~~~
((((((    ( COALESCE (mytable.oiuqweu_puiwrip_eoprdc, 0)
          + COALESCE (mytable.insdad_eoprdc, 0)
          + COALESCE (mytable.basdnasd_rates_eoprdc, 0)
          + COALESCE (mytable.poadpod_tpio_eoprdc, 0)
          + COALESCE (mytable.mkadldod_puiwrip_eoprdc, 0)
          + COALESCE (mytable.woidp_eoprdc, 0)
          + COALESCE (mytable.poiqwehda_eoprdc, 0)
          + COALESCE (mytable.htaing_eoprdc, 0)
          + COALESCE (mytable.clingd_eoprdc, 0)
          + COALESCE (mytable.lkjaldjj_eoprdc, 0)
          + COALESCE (mytable.dopasdop_eoprdc, 0)
          + COALESCE (mytable.thotd_idiaspdoid_eoprdc, 0)
          ) - 
          ( COALESCE (mytable.poadpod_tpio, 0)
          + COALESCE (mytable.mkadldod_puiwrip, 0)
          + COALESCE (mytable.insdad_poaisd, 0)
          + COALESCE (mytable.basdnasd_rates_poaisd, 0)
          + COALESCE (mytable.oiuqweu_puiwrip_poaisd, 0)
          + COALESCE (mytable.lkjfjf_dopasdop_cost_iuasudd, 0)
          + COALESCE (mytable.lkjfjf_htaing_iuasudd, 0)
          + COALESCE (mytable.prepaud_dopasdop_cost_poaisd, 0)
          + COALESCE (mytable.prepaud_mkadldod_puiwrip_poaisd, 0)
          + COALESCE (mytable.prepaud_woidp_poaisd, 0)
          + COALESCE (mytable.prepaud_poiqwehda_poaisd, 0)
          + COALESCE (mytable.thotd_idiaspdoid_poaisd, 0)
          + COALESCE (mytable.lkjfjf_woidp_iuasudd, 0)
          + COALESCE (mytable.lkjfjf_poiqwehda_iuasudd, 0)
          + COALESCE (mytable.lkjfjf_clingd_iuasudd, 0)
          + COALESCE (mytable.lkjfjf_lkjaldjj_iuasudd, 0)
          + COALESCE (mytable.prepaud_clingd_poaisd, 0)
          + COALESCE (mytable.prepaud_lkjaldjj_poaisd, 0)
          + COALESCE (mytable.prepaud_htaing_poaisd, 0)
          + COALESCE (mytable.prepaud_thotd_idiaspdoid_poaisd, 0)
          + COALESCE (mytable.lkjfjf_thotd_idiaspdoid_iuasudd, 0)
          + COALESCE (mytable.lkjfjf_mkadldod_puiwrip_iuasudd, 0)
          + COALESCE (mytable.dopasdop_eoprdc_poaisd, 0)
          + COALESCE (mytable.htaing_poaisd, 0)
          + COALESCE (mytable.clingd_poaisd, 0)
          + COALESCE (mytable.woidp_poaisd, 0)
          + COALESCE (mytable.poiqwehda_poaisd, 0)
          + COALESCE (mytable.lkjaldjj_poaisd, 0)
          )
))))))
~~~~

consider the expression `run aExpr input`  where `input` is the above string. Parsing this does terminate, but you definitely start noticing the cpu time, and if you profile you can see some suspiciously large values. We had some larger queries that did _not_ terminate, but with the same underlying problem.

## Analysis

There are a couple of parsers around `aExpr`, `customizedAExpr`, `cExpr`, `customizedCExpr` that have alternatives with common prefixes and with ambiguous parses. 

1) Examples of common prefixes are:

- spaces in alternatives (`customizedAExpr`/`suffix`)
- open parenthesis + `aExpr` is a prefix of both `InParensCExpr` or `ImplicitRowCExpr`
- `colId` is a prefix of both `FuncCExpr` and `ColumnrefCExpr`

On their own these might be harmless, but once such cases nest they can create a problem. I _think_ the last of the above is just a constant-factor problem (so rather harmless); still, I cleaned these up in the PR because a) it was relatively simple to do b) It is hard to diagnose which common prefixes lead to problems, so it makes debugging the whole thing easier if they get cleaned up.

2) As example of a ambiguous parse consider the following two trees:

~~~~
InParensCExpr (SelectWithParensCExpr (NoParensSelectWithParens a) Nothing)
SelectWithParensCExpr (WithParensSelectWithParens a) Nothing
~~~~

both should correspond to something like `((SELECT …))`.

The ambiguity _might_ be known because the hedgehog tests explicitly generate only one of those two options (see https://github.com/nikita-volkov/postgresql-syntax/blob/6caff75d1a22af91806b689513888561731fb839/hedgehog-test/Main/Gen.hs#L475).

## Approach

I follow a simple process: Take any alternative (`asum [..]`) where alternatives have common prefixes, remove those alternatives and replace with a single new one that first matches the common prefix, then branches again. As an example, I replaced

~~~~
… = asum
  [ …
  , inParens foo
  , inParens bar
  , …
  ]
~~~~

with

~~~~
… = asum
  [ …
  , char '(' *> space *> asum [ fooTail, barTail ] *< space *< char ')'
  , …
  ]
~~~~

It is not always this simple, for example if the `inParens` appears deeper in the call stack then this gets messier, with multiple new `XTail` bindings.

## Notes

- I am not sure if I applied `endHead` and `wrapHead` correctly everywhere. The tests pass, but I am not sure that the tests cover the readability of the error-messages (iiuc the "HeadParser" also has the purpose of helping with those).
- There are some cases still where the order of the parsers (in `asum`s) matters. I don't think that is ideal, nor should it be necessary. As I understand it this might be due to committing to some branch (via `endHead`) too soon. But it is also harmless given that the tests pass.
- I added https://github.com/proda-ai/postgresql-syntax/blob/e0450870e35dcbfd4a11d6757bcb54c4bd65cc10/library/PostgresqlSyntax/Parsing.hs#L1288-L1301 after resolving the ambiguity-problem: The tests expect nested `WithParensSelectWithParens`, so the parser simply converts `InParensCExpr (CExprAExpr …)` to that where necessary. Could instead fix the tests, but maybe the slightly flatter trees for nested selects are worth this cost. I have no idea why exactly the AST types are defined as they are, to be honest.
- I feel like the code now combines several different approaches to ensure good performance:
  - the `customizedCExpr` approach to parameterise by some child-parser
  - just defining multiple parsers
  - defining "tail" parsers (what I did here)

  I am not proud of my addition as it makes the whole logic harder to follow. It might be cleaner make use of continuations, but still that does not improve things much. But I don't see an easy-to-read/maintain approach with good performance ..

  At least I only had to touch the "innermost loop" when parsing expressions, so maybe it is worth it.

- the fact that this https://github.com/nikita-volkov/postgresql-syntax/blob/6caff75d1a22af91806b689513888561731fb839/library/PostgresqlSyntax/Parsing.hs#L1025 uses `aExpr` instead of `base` means that a) you get a more "left-leaning" output tree but also b) that if parsing fails, you might end up failing again and again for every level of a nested `aExpr`. Same for `bExpr`. I left a note about this in the code. Could be fixed by the same "parse different tree (using `base`), then post-process to restructure the tree" approach that I used for nested selects.
- might be nice to have performance tests included. There should be some simple trivial expression like `((((((((((a+b))))))))))` that where parsing does not terminate on master but is instant with this PR. Might need a bit more nesting. But yeah, perf tests are a bit annoying at times because they can depend on the performance of the system running the tests.