### PR TITLE
Future-proof against addition of Data.List.unsnoc

### DIFF
--- a/library/PostgresqlSyntax/Prelude.hs
+++ b/library/PostgresqlSyntax/Prelude.hs
@@ -37,7 +37,7 @@ import Data.Hashable as Exports (Hashable)
 import Data.IORef as Exports
 import Data.Int as Exports
 import Data.Ix as Exports
-import Data.List as Exports hiding (all, and, any, concat, concatMap, elem, find, foldl, foldl', foldl1, foldr, foldr1, isSubsequenceOf, mapAccumL, mapAccumR, maximum, maximumBy, minimum, minimumBy, notElem, or, product, sortOn, sum, uncons)
+import Data.List as Exports hiding (all, and, any, concat, concatMap, elem, find, foldl, foldl', foldl1, foldr, foldr1, isSubsequenceOf, mapAccumL, mapAccumR, maximum, maximumBy, minimum, minimumBy, notElem, or, product, sortOn, sum, uncons, unsnoc)
 import Data.List.NonEmpty as Exports (NonEmpty (..))
 import Data.Maybe as Exports
 import Data.Monoid as Exports hiding (First (..), Last (..), (<>))


### PR DESCRIPTION
There is a CLC proposal to add `Data.List.unsnoc` to `base`: https://github.com/haskell/core-libraries-committee/issues/165. This draft PR makes `postgresql-syntax` compatible with this potential change.