### PR TITLE
Fix local binds

### DIFF
--- a/hedgehog-test/Main.hs
+++ b/hedgehog-test/Main.hs
@@ -15,16 +15,16 @@ main =
   defaultMain
     [ checkParallel $
         Group "Parsing a rendered AST produces the same AST" $
-          let p _name _amount _gen _parser _renderer =
-                (,) _name $
-                  withDiscards (fromIntegral _amount * 200) $
-                    withTests _amount $
+          let p name amount gen parser renderer =
+                (,) name $
+                  withDiscards (fromIntegral amount * 200) $
+                    withTests amount $
                       property $ do
-                        ast <- forAll _gen
-                        let sql = Rendering.toText (_renderer ast)
+                        ast <- forAll gen
+                        let sql = Rendering.toText (renderer ast)
                          in do
                               footnote ("SQL: " <> Text.unpack sql)
-                              case Parsing.run _parser sql of
+                              case Parsing.run parser sql of
                                 Left err -> do
                                   footnote err
                                   failure

--- a/hedgehog-test/Main/Gen.hs
+++ b/hedgehog-test/Main/Gen.hs
@@ -13,9 +13,9 @@ import Prelude hiding (bit, bool, filter, fromList, maybe, sortBy)
 
 -- * Generic
 
-inSet _set = filter (flip HashSet.member _set)
+inSet set = filter (flip HashSet.member set)
 
-notInSet _set = filter (not . flip HashSet.member _set)
+notInSet set = filter (not . flip HashSet.member set)
 
 -- * Statements
 
@@ -105,8 +105,8 @@ terminalSelectNoParens =
 
 -- ** selectWithParens
 
-selectWithParens = sized $ \_size ->
-  if _size <= 1
+selectWithParens = sized $ \size ->
+  if size <= 1
     then discard
     else
       frequency
@@ -144,8 +144,8 @@ tableSimpleSelect = TableSimpleSelect <$> relationExpr
 
 valuesSimpleSelect = ValuesSimpleSelect <$> valuesClause
 
-binSimpleSelect _leftSelect =
-  BinSimpleSelect <$> selectBinOp <*> pure _leftSelect <*> maybe allOrDistinct <*> small selectClause
+binSimpleSelect leftSelect =
+  BinSimpleSelect <$> selectBinOp <*> pure leftSelect <*> maybe allOrDistinct <*> small selectClause
 
 terminalSimpleSelect = pure (NormalSimpleSelect Nothing Nothing Nothing Nothing Nothing Nothing Nothing)
 

--- a/library/PostgresqlSyntax/Extras/HeadedMegaparsec.hs
+++ b/library/PostgresqlSyntax/Extras/HeadedMegaparsec.hs
@@ -79,11 +79,11 @@ float = parse MegaparsecLexer.float
 -- * Combinators
 
 sep1 :: (Ord err, Stream strm, Megaparsec.Token strm ~ Char) => HeadedParsec err strm separtor -> HeadedParsec err strm a -> HeadedParsec err strm (NonEmpty a)
-sep1 _separator _parser = do
-  _head <- _parser
+sep1 separator parser = do
+  head <- parser
   endHead
-  _tail <- many $ _separator *> _parser
-  return (_head :| _tail)
+  tail <- many $ separator *> parser
+  return (head :| tail)
 
 sepEnd1 :: (Ord err, Stream strm, Megaparsec.Token strm ~ Char) => HeadedParsec err strm separator -> HeadedParsec err strm end -> HeadedParsec err strm el -> HeadedParsec err strm (NonEmpty el, end)
 sepEnd1 sepP endP elP = do


### PR DESCRIPTION
* The `_` prefix usually indicates unused binds. All of these binds are used so I removed the prefix.
* For the view cases that after the removal we hit an HS keyword I primed its name.

@nikita-volkov You've told me on witter DM the `_` prefix is an experiment you abandoned since, so I fixed all instances. Reduces cache miss for my brain while working with this code base.