### PR TITLE
Support FOR locking clause before LIMIT/OFFSET

### DIFF
--- a/library/PostgresqlSyntax/Parsing.hs
+++ b/library/PostgresqlSyntax/Parsing.hs
@@ -336,9 +336,17 @@ selectNoParens = withSelectNoParens <|> simpleSelectNoParens
 sharedSelectNoParens with = do
   select <- selectClause
   sort <- optional (space1 *> sortClause)
-  limit <- optional (space1 *> selectLimit)
-  forLocking <- optional (space1 *> forLockingClause)
+  (limit, forLocking) <- limitFirst <|> forLockingFirst <|> pure (Nothing, Nothing)
   return (SelectNoParens with select sort limit forLocking)
+  where
+    limitFirst = do
+      limit <- space1 *> selectLimit
+      forLocking <- optional (space1 *> forLockingClause)
+      pure (Just limit, forLocking)
+    forLockingFirst = do
+      forLocking <- space1 *> forLockingClause
+      limit <- optional (space1 *> selectLimit)
+      pure (limit, Just forLocking)
 
 -- |
 -- The one that doesn't start with \"WITH\".

--- a/tasty-test/Main.hs
+++ b/tasty-test/Main.hs
@@ -26,7 +26,17 @@ main =
                       \inner join edgenode.usere_provider as p\n\
                       \on u.id = p.user_id\n\
                       \inner join edgenode.provider_branch as b\n\
-                      \on b.provider_fk = p.provider_id"
+                      \on b.provider_fk = p.provider_id",
+                      -- FOR locking clause before LIMIT (PostgreSQL accepts both orderings)
+                      "select * from items for update limit 1",
+                      "select * from items limit 1 for update",
+                      "select * from items for share limit 10",
+                      "select * from items for no key update limit 1",
+                      "select * from items for key share limit 1",
+                      "select * from items for update of items nowait limit 1",
+                      "select * from items for update skip locked limit 1",
+                      "select * from items order by id for update limit 1",
+                      "select * from items for update offset 5 limit 10"
                     ],
                   testParserOnAllInputs
                     "typename"


### PR DESCRIPTION
hey nikita, just ran into this one today :)

---

PostgreSQL accepts both orderings of the FOR locking clause and LIMIT/OFFSET in `select_no_parens`:

```
select_clause opt_sort_clause for_locking_clause opt_select_limit
select_clause opt_sort_clause select_limit opt_for_locking_clause
```

(This is also documented in a comment at `simpleSelectNoParens`.)

The parser currently only handles the second form (LIMIT before FOR), so queries like `SELECT * FROM t FOR UPDATE LIMIT 1` fail to parse.

This PR updates `sharedSelectNoParens` to try both orderings using `<|>`. No AST or renderer changes are needed.

Tests added for all locking strengths (UPDATE, SHARE, NO KEY UPDATE, KEY SHARE) with LIMIT, as well as OF/NOWAIT/SKIP LOCKED variants.