### PR TITLE
feat: provide better error management

### DIFF
--- a/library/PostgresqlSyntax/Extras/Error.hs
+++ b/library/PostgresqlSyntax/Extras/Error.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+-- |
+-- Generic helpers for Error handling in HeadedMegaParsec.
+module PostgresqlSyntax.Extras.Error where
+
+import Control.Monad.State.Strict
+  ( MonadState (get, put),
+    runState,
+  )
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Set as Set
+import qualified Data.Text as Text
+import PostgresqlSyntax.Prelude hiding (cons, fromList, head, init, last, reverse, tail, uncons)
+import Text.Megaparsec hiding (errorBundlePrettyWith)
+import Text.Megaparsec.Error (ErrorItem)
+
+-- | Render all Megaparsec parsing errors as a list of position ('Text.Megaparsec.SourcePos') and messages.
+errorBundlePrettyStruct ::
+  forall s e.
+  ( VisualStream s,
+    TraversableStream s,
+    ShowErrorComponent e
+  ) =>
+  -- | Parse error bundle to display
+  ParseErrorBundle s e ->
+  -- | Textual rendition of the bundle
+  NonEmpty (SourcePos, String)
+errorBundlePrettyStruct ParseErrorBundle {bundleErrors, bundlePosState} =
+  fst $ attachSourcePosAndMessage renderError bundleErrors bundlePosState
+  where
+    renderError epos e = (epos, parseErrorTextPretty e)
+
+-- | A custom version of 'Text.Megaparsec.attachSourcePos' to provide the NonEmpty list of errors with their position while only traversing the errors list once.
+attachSourcePosAndMessage ::
+  (TraversableStream s) =>
+  -- | Format function for a single 'ParseError' and its 'SourcePos'
+  (SourcePos -> ParseError s e -> (SourcePos, String)) ->
+  -- | The collection of items
+  NonEmpty (ParseError s e) ->
+  -- | Initial 'PosState'
+  PosState s ->
+  -- | The collection with 'SourcePos'es added and the final 'PosState'
+  (NonEmpty (SourcePos, String), PosState s)
+attachSourcePosAndMessage format xs = runState (traverse f xs)
+  where
+    f a = do
+      pst <- get
+      let pst' = reachOffsetNoLine (errorOffset a) pst
+      put pst'
+      let position = pstateSourcePos pst'
+      return $ format position a
+
+-- | Provide an equivalent to megaparsec's 'Text.Megaparsec.chunk' in a context where we manipulate the texts directly.
+chunkFailure ::
+  (Token s ~ Char, MonadParsec e s m) =>
+  -- | expected chunk
+  Text ->
+  -- | actual (given) chunk
+  Text ->
+  m a
+chunkFailure expectedTxt givenTxt = failure (Just (errorItemConverter givenTxt)) (Set.fromList (pure $ errorItemConverter expectedTxt))
+  where
+    -- Note that Text.foldr' (the strict version) should probably be used instead but it doesn't exist before Text 2.x.
+    errorItemConverter t = (Tokens ((Text.foldr (NonEmpty.cons) (pure (' ' :: Char)) t)))

--- a/library/PostgresqlSyntax/Extras/HeadedMegaparsec.hs
+++ b/library/PostgresqlSyntax/Extras/HeadedMegaparsec.hs
@@ -8,6 +8,7 @@ import Control.Applicative.Combinators hiding (some)
 import Control.Applicative.Combinators.NonEmpty
 import qualified Data.Text as Text
 import HeadedMegaparsec hiding (string)
+import PostgresqlSyntax.Extras.Error (errorBundlePrettyStruct)
 import PostgresqlSyntax.Prelude hiding (bit, expr, filter, head, many, option, some, sortBy, tail, try)
 import Text.Megaparsec (Parsec, Stream, TraversableStream, VisualStream)
 import qualified Text.Megaparsec as Megaparsec
@@ -23,13 +24,11 @@ run :: (Ord err, VisualStream strm, TraversableStream strm, Megaparsec.ShowError
 run p = first Megaparsec.errorBundlePretty . runParser p
 
 -- |
--- Run the parser but returns all the error messages separated, along with their offset in the parsed message.
-runParserWithErrorPos :: (Show (Megaparsec.Token strm), Show e, Ord e, VisualStream strm, TraversableStream strm, Megaparsec.ShowErrorComponent e) => HeadedParsec e strm a -> strm -> Either (NonEmpty (Int, String)) a
+-- Run the parser but returns all the error messages separated, along with their position ('Megaparsec.SourcePos') in the parsed message.
+runParserWithErrorPos :: (Show (Megaparsec.Token strm), Show e, Ord e, VisualStream strm, TraversableStream strm, Megaparsec.ShowErrorComponent e) => HeadedParsec e strm a -> strm -> Either (NonEmpty (Megaparsec.SourcePos, String)) a
 runParserWithErrorPos p s = case runParser p s of
-  Left err -> Left (extractor <$> Megaparsec.bundleErrors err)
+  Left err -> Left (errorBundlePrettyStruct err)
   Right v -> Right v
-  where
-    extractor x = (Megaparsec.errorOffset x, Megaparsec.parseErrorPretty x)
 
 runParser :: (Ord e, VisualStream strm, TraversableStream strm) => HeadedParsec e strm a -> strm -> Either (Megaparsec.ParseErrorBundle strm e) a
 runParser p = Megaparsec.runParser (toParsec p <* Megaparsec.eof) ""

--- a/library/PostgresqlSyntax/Parsing.hs
+++ b/library/PostgresqlSyntax/Parsing.hs
@@ -30,9 +30,11 @@ module PostgresqlSyntax.Parsing where
 import Control.Applicative.Combinators hiding (some)
 import Control.Applicative.Combinators.NonEmpty
 import qualified Data.HashSet as HashSet
+import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Text as Text
 import HeadedMegaparsec hiding (string)
 import PostgresqlSyntax.Ast
+import PostgresqlSyntax.Extras.Error (chunkFailure)
 import PostgresqlSyntax.Extras.HeadedMegaparsec hiding (run)
 import qualified PostgresqlSyntax.Extras.HeadedMegaparsec as Extras
 import qualified PostgresqlSyntax.Extras.NonEmpty as NonEmpty
@@ -54,7 +56,7 @@ type Parser = HeadedParsec Void Text
 run :: Parser a -> Text -> Either String a
 run = Extras.run
 
-runWithPosError :: Parser a -> Text -> Either (NonEmpty (Int, String)) a
+runWithPosError :: Parser a -> Text -> Either (NonEmpty (Megaparsec.SourcePos, String)) a
 runWithPosError = Extras.runParserWithErrorPos
 
 -- * Helpers
@@ -2001,7 +2003,12 @@ anyKeyword = parse
     return (Text.toLower (Text.cons firstChar remainder))
 
 -- | Expected keyword
-keyword a = mfilter (a ==) anyKeyword
+keyword :: (Megaparsec.Tokens s ~ Text, Megaparsec.Token s ~ Char, Ord e, Megaparsec.Stream s) => Text -> HeadedParsec e s Text
+keyword expectedKeyword = do
+  parsedTxt <- anyKeyword
+  if expectedKeyword == parsedTxt
+    then pure parsedTxt
+    else parse $ chunkFailure expectedKeyword parsedTxt
 
 -- |
 -- Consume a keyphrase, ignoring case and types of spaces between words.

--- a/postgresql-syntax.cabal
+++ b/postgresql-syntax.cabal
@@ -75,6 +75,7 @@ library
 
   other-modules:
     PostgresqlSyntax.CharSet
+    PostgresqlSyntax.Extras.Error
     PostgresqlSyntax.Extras.HeadedMegaparsec
     PostgresqlSyntax.Extras.NonEmpty
     PostgresqlSyntax.Extras.TextBuilder
@@ -82,12 +83,17 @@ library
     PostgresqlSyntax.Prelude
 
   build-depends:
+    -- megaparsec 9.8 introduces a breaking change which completely modifies the behavior of error reporting
+    -- (see : https://github.com/mrkkrp/megaparsec/issues/412 and https://github.com/mrkkrp/megaparsec/pull/599/changes)
+    -- bumping to 9.8 requires a careful attention to HeadedMegaparsec <|> usage to revert to pre-9.8 behavior (which is the one we want).
     base >=4.12 && <5,
     bytestring >=0.10 && <0.13,
     case-insensitive >=1.2.1 && <2,
+    containers >=0.4 && <1,
     hashable >=1.3.5 && <2,
     headed-megaparsec >=0.2.0.1 && <0.3,
-    megaparsec >=9.2 && <10,
+    megaparsec >=9.2 && <9.8,
+    mtl >=1.21.2 && <3,
     parser-combinators >=1.3 && <1.4,
     text >=1 && <3,
     text-builder >=1 && <1.1,
@@ -100,6 +106,7 @@ test-suite tasty-test
   main-is: Main.hs
   ghc-options: -threaded
   build-depends:
+    megaparsec >=9.2 && <9.8,
     postgresql-syntax,
     rerebase <2,
     tasty >=1.2.3 && <2,

--- a/tasty-test/Main.hs
+++ b/tasty-test/Main.hs
@@ -5,6 +5,7 @@ import qualified Data.Text as Text
 import qualified PostgresqlSyntax.Parsing as Parsing
 import Test.Tasty
 import Test.Tasty.HUnit
+import Text.Megaparsec.Pos (sourcePosPretty)
 import Prelude hiding (assert)
 
 main :: IO ()
@@ -59,14 +60,40 @@ main =
                       "jsonb"
                     ]
                 ],
+        testGroup "Errors one"
+          $ let testParserOnAllInputs parserName parser inputs res =
+                  testCase parserName
+                    $ forM_ inputs
+                    $ \input -> case Parsing.run parser input of
+                      Left err -> show err @?= res
+                      Right _ -> return ()
+             in [ testParserOnAllInputs
+                    "preparableStmt"
+                    Parsing.preparableStmt
+                    [ "SELECT id FROM as"
+                    ]
+                    "\"1:18:\\n  |\\n1 | SELECT id FROM as\\n  |                  ^\\nReserved keyword \\\"as\\\" used as an identifier. If that's what you intend, you have to wrap it in double quotes.\\n\""
+                ],
         testGroup "Error reporting"
           $ let testParserOnAllInputs parserName parser inputs res =
                   testCase parserName
                     $ forM_ inputs
                     $ \input -> case Parsing.runWithPosError parser input of
-                      Left err -> show (NonEmpty.head err) @?= res
+                      Left err ->
+                        let formattedErrList = (\(p, m) -> sourcePosPretty p <> " " <> m) <$> err
+                         in res `elem` formattedErrList @? "Missing error message " <> res <> " in " <> show formattedErrList
                       Right _ -> return ()
              in [ testParserOnAllInputs
+                    "Typo in FROM keyword"
+                    Parsing.preparableStmt
+                    ["select u.id :: int8 fom auth.user as u"]
+                    "1:24 unexpected space\nexpecting end of input\n",
+                  testParserOnAllInputs
+                    "Typo in select keyword"
+                    Parsing.preparableStmt
+                    ["SLECT id FROM qsdqsd"]
+                    "1:6 unexpected \"slect \"\nexpecting \"call \", \"delete \", \"insert \", \"select \", \"table \", \"update \", \"values \", or \"with \"\n",
+                  testParserOnAllInputs
                     "Typo in FROM keyword"
                     Parsing.preparableStmt
                     [ "select i :: int8 fom auth.user as u\n\
@@ -75,13 +102,13 @@ main =
                       \inner join edgenode.provider_branch as b\n\
                       \on b.provider_fk = p.provider_id"
                     ]
-                    "(20,\"offset=20:\\nunexpected space\\nexpecting end of input\\n\")",
+                    "1:21 unexpected space\nexpecting end of input\n",
                   testParserOnAllInputs
                     "Typo in NOT keyword"
                     Parsing.preparableStmt
                     [ "select i :: int8 from auth.user as u\n\
                       \WHERE u.id IS NO NULL && TRUE"
                     ]
-                    "(53,\"offset=53:\\nexpecting white space\\n\")"
+                    "2:17 unexpected \"no \"\nexpecting \"distinct \", \"document \", \"false \", \"null \", \"of \", \"true \", \"unknown \", or white space\n"
                 ]
       ]


### PR DESCRIPTION
Hey @nikita-volkov, this PR improves two issues over the status quo:

- Better error messages when using the keyword function
- Ship the entire Megaparsec.SourcePos object (instead of the offset as un Int) to communicate the error position to better achieve https://github.com/nikita-volkov/hasql-th/issues/35) 

Unfortunately, I tried a few things without good results to do #18, so I feel like the parser is not the best tool for this job. I suppose an SQL linter with access to the schema would be a lot better.

