### PR TITLE
Fix OFFSET/aExpr round-trip failure for OPERATOR(...) prefix

### DIFF
--- a/library/PostgresqlSyntax/Parsing.hs
+++ b/library/PostgresqlSyntax/Parsing.hs
@@ -1367,7 +1367,14 @@ trimList =
       ExprListTrimList <$> exprList
     ]
 
-funcApplication = inParensWithLabel FuncApplication funcName (optional funcApplicationParams)
+-- |
+-- \"operator\" immediately followed by \"(\" is always parsed as the start
+-- of a qualified operator (@OPERATOR(...)@), never as a call to a function
+-- literally named \"operator\", mirroring how real PostgreSQL's grammar
+-- resolves the conflict between these two productions in favor of qual_op.
+funcApplication =
+  notFollowedBy (keyword "operator" *> space *> char '(')
+    *> inParensWithLabel FuncApplication funcName (optional funcApplicationParams)
 
 funcApplicationParams =
   asum


### PR DESCRIPTION
## Summary
- Fixes #11: `funcApplication` let `operator` be parsed as a plain function name when immediately followed by `(`, competing with the `qual_op` production (`OPERATOR(...)`) that PostgreSQL's grammar always resolves in favor of `qual_op` at that position (shift-over-reduce). Contexts that invoke `cExpr` directly — such as `selectFetchFirstValue`, used by `OFFSET`/`FETCH` clauses — could therefore misinterpret input like `OPERATOR (*) ROW () OVERLAPS (aa, aa)` as a truncated function call instead of the intended prefix-qualified-operator expression, breaking render → parse round-tripping.
- Verified #12 (IN-expression vs. parenthesized subquery ambiguity) is already fixed by 58a0773 and still holds under the current hedgehog suite; no further change needed there.

## Test plan
- [x] `cabal build` succeeds
- [x] `cabal run hedgehog-test` — all 4 property groups pass (typename, tableRef, aExpr x60000, preparableStmt) across multiple runs
- [x] Manually reproduced and confirmed fixed the exact ASTs reported in #11 and #12 via a standalone repro harness
- [x] `cabal test tasty-test` — confirmed the one failing case ("Typo in NOT keyword" offset assertion) is pre-existing on master, unaffected by this change